### PR TITLE
Add metrics view models

### DIFF
--- a/models/metrics/bounce_rate.sql
+++ b/models/metrics/bounce_rate.sql
@@ -1,0 +1,35 @@
+with session_agg as (
+    select 
+        session_id
+        , min(device_created_timestamp::date) as session_start_date
+        , count_if(event_name = 'page_view') as number_of_page_views_in_session
+        , count_if(event_name = 'page_ping') as number_of_page_pings_in_session
+        , count_if(event_name = 'link_click') as number_of_link_clicks_in_session
+    from {{ ref('stg_web_events') }}
+    group by session_id
+)
+
+, bounces as (
+    select
+        session_id
+        , session_start_date
+    from session_agg
+    where number_of_page_views_in_session = 1
+        and number_of_page_pings_in_session = 0
+        and number_of_link_clicks_in_session = 0
+)
+
+, final as (
+    select
+        session_agg.session_start_date
+        , count(distinct session_agg.session_id) as number_of_sessions
+        , count(distinct bounces.session_id) as number_of_bounces
+        , round(div0(count(distinct bounces.session_id), count(distinct session_agg.session_id)) * 100,0) as bounce_rate_percent
+    from session_agg
+    left join bounces
+        on session_agg.session_start_date = bounces.session_start_date
+    group by 1
+    order by 1 desc
+)
+
+select * from final

--- a/models/metrics/bounce_rate.sql
+++ b/models/metrics/bounce_rate.sql
@@ -14,6 +14,9 @@ with session_agg as (
         session_id
         , session_start_date
     from session_agg
+
+    -- There are some sessions where the number of page views in a session is 0
+    -- The cases are not bounces, as they will have at least 1 ping or click event (or wouldn't appear in the dataset at all)
     where number_of_page_views_in_session = 1
         and number_of_page_pings_in_session = 0
         and number_of_link_clicks_in_session = 0

--- a/models/metrics/engaged_time.sql
+++ b/models/metrics/engaged_time.sql
@@ -1,0 +1,52 @@
+with web_events as (select * from {{ ref('stg_web_events') }})
+, bounce_rate as (select * from {{ ref('bounce_rate') }})
+
+-- Engaged time per page view will be calculated by multiplying the number of pings by the ping 'heartbeat' / period
+, engaged_time as (
+    select 
+        page_view_id
+        , count_if(event_name = 'page_ping') as num_pings
+
+        -- From analysis of the data, we can infer that the time between page pings is 10 seconds
+        , count_if(event_name = 'page_ping') * 10 as engaged_time_seconds
+        , min(device_created_timestamp::date) as date_of_page_view
+    from web_events
+    group by 1
+)
+
+, page_views_agg as (
+    select
+        date_of_page_view
+        , sum(engaged_time_seconds) as total_engaged_time_seconds
+        , count(distinct page_view_id) as number_of_page_views
+    from engaged_time
+    group by 1
+) 
+
+, calculate_metric as (
+    select 
+        page_views_agg.date_of_page_view
+        , page_views_agg.total_engaged_time_seconds
+        , page_views_agg.number_of_page_views
+
+        -- By definition, number of bounces = number of page views that bounced, as a bounce is a session with only 1 page view in it
+        , bounce_rate.number_of_bounces
+        , div0(page_views_agg.total_engaged_time_seconds, (number_of_page_views - number_of_bounces)) as average_page_engaged_time_seconds
+    from page_views_agg
+    left join bounce_rate
+        on page_views_agg.date_of_page_view = bounce_rate.session_start_date
+    group by 1, 2, 3, 4
+)
+
+, final as (
+    select 
+        date_of_page_view
+        , round(average_page_engaged_time_seconds, 0) as average_page_engaged_time_seconds
+        , round(average_page_engaged_time_seconds / 60 , 1) as average_page_engaged_time_minutes
+        , total_engaged_time_seconds
+        , number_of_page_views
+        , number_of_bounces
+    from calculate_metric
+)
+
+select * from final

--- a/models/metrics/scroll_depth.sql
+++ b/models/metrics/scroll_depth.sql
@@ -1,0 +1,41 @@
+with web_events as (select * from {{ ref('stg_web_events') }})
+
+-- Calculate some of the page parameters, e.g. y offsets and page height
+, page_min_max as (
+    select 
+        page_view_id
+        , min(device_created_timestamp::date) as date_of_page_view
+        
+        -- Use the maximum page height for calculation, as there are a number of cases where the page_height changes on a single page view
+        -- e.g. c2ee0680-91f5-4420-a6fe-d268f22ddcf2
+        , max(page_height) as max_page_height
+
+        -- There are some cases where the minimum y offset is non-zero, e.g. the user may not have seen the top of the page
+        -- For now, we'll ignore these cases as the metric is scroll depth, not necesearily the percentage of content seen
+        , min(y_offset_min) as min_y_offset
+        , max(y_offset_max) as max_y_offset
+    from stg_web_events
+    group by 1
+)
+
+-- Calculate the scroll depth for each page view
+, page_view_average_depth as (
+    select    
+        page_view_id
+        , date_of_page_view
+        , max_page_height
+        , max_y_offset
+        , coalesce(max_y_offset / max_page_height, 0) * 100 as percent_of_page_seen
+    from page_min_max
+)
+
+-- Calculate the average scroll depth at a daily level
+, final as (
+    select
+        date_of_page_view
+        , avg(percent_of_page_seen) as average_scroll_depth
+    from page_view_average_depth
+    group by 1
+)
+
+select * from final

--- a/models/metrics/user_journey.sql
+++ b/models/metrics/user_journey.sql
@@ -1,30 +1,76 @@
-with next_page_host as (
+with web_events as (select * from {{ ref('stg_web_events') }})
+
+, examine_first_session as (
     select     
         device_created_timestamp::date as date_journey_started
         , user_cookie
-        , first_value(page_host_name) over (partition by user_cookie, session_id order by device_created_timestamp asc) as first_page_host
-        , lead(page_host_name) over (partition by user_cookie, session_id order by device_created_timestamp asc) as next_page_view_host_name
-    from stg_web_events
+        , page_host_name
+
+        -- This will be used to identify if the user landed on the main site on the first page in their firstsession
+        , row_number() over (
+            partition by user_cookie
+                , session_id 
+            order by device_created_timestamp asc
+        ) as page_view_ordinal_in_session
+
+        -- This identifies when the user switched platforms onto the discourse site
+        , conditional_change_event(page_host_name) over (
+            partition by user_cookie
+            , session_id 
+            order by device_created_timestamp asc
+        ) as changed_platforms
+    from web_events
     where event_name = 'page_view'
     and session_increment = 1
 )
 
-, count_users_with_journey_to_track as (
+-- This CTE is one row per user_cookie, and has 2 flag columns:
+-- The first indiciates if the user started their journey on the main host platform
+-- The second indicates if the user switched to the discourse platform at some point within their first session
+, valid_user_journeys as (
     select 
         date_journey_started
-        , count(distinct user_cookie) as number_of_users
-        , count_if(first_page_host = 'snowplowanalytics.com' and next_page_view_host_name = 'discourse.snowplowanalytics.com') as users_with_valid_journey
-    from next_page_host
-    group by 1
+        , user_cookie
+
+        -- Use max() as we are aggregating over multiple page views per user
+        , max(
+            case
+                when page_view_ordinal_in_session = 1 and page_host_name = 'snowplowanalytics.com' then 1
+                else 0 
+            end
+        ) as started_journey_on_main_site
+        , max(
+            case
+                when changed_platforms = 1 and page_host_name = 'discourse.snowplowanalytics.com' then 1
+                else 0
+            end
+        ) as switched_to_discource_platform_in_session
+    from examine_first_session
+
+    -- Limit to just the 2 important page views in the user's first session
+    where page_view_ordinal_in_session = 1
+        or changed_platforms = 1
+    group by 1, 2
 )
 
+-- Perform final counts and aggregations
 , final as (
     select 
         date_journey_started
-        , number_of_users
-        , users_with_valid_journey
-        , div0(users_with_valid_journey, number_of_users) * 100 as percent_of_users_with_user_journey
-    from count_users_with_journey_to_track
+        , count(distinct user_cookie) as number_of_users
+        , count_if(
+            started_journey_on_main_site = 1
+                and switched_to_discource_platform_in_session = 1
+        ) as number_of_users_with_valid_user_journey
+        , div0(
+            count_if(
+                started_journey_on_main_site = 1 
+                    and switched_to_discource_platform_in_session = 1
+            )
+            , count(distinct user_cookie)
+        ) * 100 as percent_of_users_with_user_journey
+    from valid_user_journeys
+    group by 1
 )
 
 select * from final

--- a/models/metrics/user_journey.sql
+++ b/models/metrics/user_journey.sql
@@ -1,0 +1,30 @@
+with next_page_host as (
+    select     
+        device_created_timestamp::date as date_journey_started
+        , user_cookie
+        , first_value(page_host_name) over (partition by user_cookie, session_id order by device_created_timestamp asc) as first_page_host
+        , lead(page_host_name) over (partition by user_cookie, session_id order by device_created_timestamp asc) as next_page_view_host_name
+    from stg_web_events
+    where event_name = 'page_view'
+    and session_increment = 1
+)
+
+, count_users_with_journey_to_track as (
+    select 
+        date_journey_started
+        , count(distinct user_cookie) as number_of_users
+        , count_if(first_page_host = 'snowplowanalytics.com' and next_page_view_host_name = 'discourse.snowplowanalytics.com') as users_with_valid_journey
+    from next_page_host
+    group by 1
+)
+
+, final as (
+    select 
+        date_journey_started
+        , number_of_users
+        , users_with_valid_journey
+        , div0(users_with_valid_journey, number_of_users) * 100 as percent_of_users_with_user_journey
+    from count_users_with_journey_to_track
+)
+
+select * from final


### PR DESCRIPTION
## PR summary
- [ ] Documentation edited/added (dbt docs)
- [ ] Checked that SQL follows style guide by running the SQLFluff linter `sqlfluff lint models/`
- [ ] Macros used where appropriate for code abstraction

## Testing
- [ ] Every model should be tested AND documented in a `schema.yml` file. At minimum, unique, not nullable fields, and foreign key constraints should be tested, if applicable ([Docs](https://docs.getdbt.com/docs/testing-and-documentation))
- [X] The output of dbt test should be pasted directly below this point

<details>
<summary> results of running `dbt build` </summary>
<pre><code>


20:01:42  Found 5 models, 0 tests, 0 snapshots, 0 analyses, 306 macros, 0 operations, 1 seed file, 0 sources, 0 exposures, 0 metrics
20:01:42  
20:01:44  Concurrency: 4 threads (target='dev')
20:01:44  
20:01:44  1 of 6 START seed file dev.sa_skillset_dataset ......................................................................... [RUN]
20:05:07  1 of 6 OK loaded seed file dev.sa_skillset_dataset ..................................................................... [INSERT 36112 in 203.02s]
20:05:07  2 of 6 START sql view model dev.stg_web_events ......................................................................... [RUN]
20:05:09  2 of 6 OK created sql view model dev.stg_web_events .................................................................... [SUCCESS 1 in 1.45s]
20:05:09  3 of 6 START sql view model dev.bounce_rate ............................................................................ [RUN]
20:05:09  4 of 6 START sql view model dev.scroll_depth ........................................................................... [RUN]
20:05:09  5 of 6 START sql view model dev.user_journey ........................................................................... [RUN]
20:05:10  4 of 6 OK created sql view model dev.scroll_depth ...................................................................... [SUCCESS 1 in 1.48s]
20:05:11  3 of 6 OK created sql view model dev.bounce_rate ....................................................................... [SUCCESS 1 in 2.18s]
20:05:11  6 of 6 START sql view model dev.engaged_time ........................................................................... [RUN]
20:05:11  5 of 6 OK created sql view model dev.user_journey ...................................................................... [SUCCESS 1 in 2.42s]
20:05:12  6 of 6 OK created sql view model dev.engaged_time ...................................................................... [SUCCESS 1 in 1.13s]
20:05:12  
20:05:12  Finished running 1 seed, 5 view models in 0 hours 3 minutes and 29.76 seconds (209.76s).
20:05:12  
20:05:12  Completed successfully
20:05:12  
20:05:12  Done. PASS=6 WARN=0 ERROR=0 SKIP=0 TOTAL=6
</code></pre>
</details>

## Change Overview _[Required]_
This PR introduces views for calculating 4 metrics, per the SA assignment

### Why was it changed?
To introduce the metrics views